### PR TITLE
Enhancement: User and Client info on Revoke Grant

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
@@ -385,7 +385,7 @@ module.controller('UserDetailCtrl', function($scope, realm, user, BruteForceUser
                                              Components,
                                              UserImpersonation, RequiredActions,
                                              UserStorageOperations,
-                                             $location, $http, Dialog, Notifications, $translate, Groups) {
+                                             $location, $http, Dialog, Notifications, $translate, $route, Groups) {
     $scope.realm = realm;
     $scope.create = !user.id;
     $scope.editUsername = $scope.create || $scope.realm.editUsernameAllowed;
@@ -488,10 +488,8 @@ module.controller('UserDetailCtrl', function($scope, realm, user, BruteForceUser
                 realm: realm.realm,
                 userId: $scope.user.id
             }, $scope.user, function () {
-                $scope.changed = false;
-                convertAttributeValuesToString($scope.user);
-                user = angular.copy($scope.user);
                 Notifications.success($translate.instant('user.edit.success'));
+                $route.reload();
             });
         }
     };


### PR DESCRIPTION
I couldn't find an open issue on JIRA nor the mailing. This is an enhancement I've been using for a while, as a part of the efforts to achieve compliance with LGPD (sort of Brazilian GPDR). With this, an event listener could get user and client IDs involved in a revoke grant event. 